### PR TITLE
Add api validation support.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cimpress_mcp (0.0.1)
+    cimpress_mcp (0.0.2)
       prawn
       rest-client
 

--- a/lib/cimpress_mcp/cli.rb
+++ b/lib/cimpress_mcp/cli.rb
@@ -81,12 +81,21 @@ class Cli
 				upload = mcp.upload_file(file: File.new(tmpfile))
 				File.delete(tmpfile)
 				puts rasterizeResponse['ResultUrl']
+		when 'validate_api'
+			print "Swagger API Url to validate: "
+			api_url = gets.chomp
+			validate_response = mcp.validate_api(swagger_url_to_validate: api_url)
+			if validate_response["failures"].any? then
+				puts "Failures: \n  #{validate_response['failures']}"
+			else
+				puts "Success. No errors found."
+			end
 		when 'get_fulfillment_recommendations'
 			puts mcp.get_fulfillment_recommendations(sku: 'VIP-44525', quantity: 250, country: 'US', postal_code: '01331')
 		when 'create_barcode'
 			createBarcodeResponse = mcp.create_barcode()
 			puts createBarcodeResponse
-			when 'health_check'
+    when 'health_check'
 				puts mcp.health_checks()
 		when 'test_product'
 			#make sure we can get the surface spec for the provided SKU
@@ -102,4 +111,5 @@ class Cli
 		end
 
 	end
+end
 end

--- a/lib/cimpress_mcp/config.rb
+++ b/lib/cimpress_mcp/config.rb
@@ -29,6 +29,11 @@ module Cimpress_mcp
             :client_id => '0o9e54NwpXutAxVkylQXzhoRZN47NEGy',
             :health_check_url => '',
             :endpoint_url => 'https://recommendations.commerce.cimpress.io/v3/'
+        },
+        :api_validation => {
+            :client_id => 'LbiZHnAESDDfXhiqxjwvc7cPAEbaN2gP',
+            :health_check_url => 'https://api.cimpress.io/tools/api-validator/v1/healthcheck',
+            :endpoint_url => 'https://api.cimpress.io/tools/api-validator/v1/'
         }
     }
 end


### PR DESCRIPTION
Was able to successfully get this to validate existing APIs using the api swagger validation service. 

Example of swagger that will generate api validation errors:  https://developer.cimpress.io/2016-04-01_11-33_swagger-api3.json